### PR TITLE
feat: Add previous/next post navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -12,3 +12,33 @@
 input[type="text"], textarea {
   border: 1px solid #ddd;
 }
+
+.navigation-buttons {
+  margin-top: 1rem; /* mt-4 */
+  padding-top: 1rem; /* pt-4 */
+  border-top: 1px solid #e5e7eb; /* border-gray-300 */
+  display: flex;
+  justify-content: space-between;
+}
+
+/* Styling for dark mode can be added if necessary, matching dark:border-gray-600 */
+/* For example: */
+/* .dark .navigation-buttons { */
+/*   border-top-color: #4b5563; /* border-gray-600 */
+/* } */
+/* For now, let's add the dark mode example directly as there's no other dark mode setup */
+@media (prefers-color-scheme: dark) {
+  .navigation-buttons {
+    border-top-color: #4b5563; /* border-gray-600 */
+  }
+}
+
+
+.navigation-buttons a {
+  color: #3b82f6; /* text-blue-500 */
+  text-decoration: none;
+}
+
+.navigation-buttons a:hover {
+  text-decoration: underline;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,8 +1,8 @@
 // main.js
 // 筆記檔案清單
 const notes = [
-  { id: 'intro', title: '入門介紹', file: 'notes/intro.md' },
-  { id: 'js-array', title: 'JavaScript 陣列', file: 'notes/js-array.md' },
+  { id: 'intro', title: '入門介紹', file: 'notes/intro.md', prev: null, next: 'js-array' },
+  { id: 'js-array', title: 'JavaScript 陣列', file: 'notes/js-array.md', prev: 'intro', next: null },
 ];
 
 // DOM 元素
@@ -27,6 +27,37 @@ async function loadNote(id) {
   const res = await fetch(note.file);
   const md = await res.text();
   noteContent.innerHTML = marked.parse(md);
+
+  // Add navigation buttons
+  let navButtonsDiv = noteContent.querySelector('.navigation-buttons');
+  if (!navButtonsDiv) {
+    navButtonsDiv = document.createElement('div');
+    navButtonsDiv.className = 'navigation-buttons mt-4 pt-4 border-t border-gray-300 dark:border-gray-600 flex justify-between';
+    noteContent.appendChild(navButtonsDiv);
+  }
+  navButtonsDiv.innerHTML = ''; // Clear existing buttons
+
+  if (note.prev) {
+    const prevLink = document.createElement('a');
+    prevLink.href = `#${note.prev}`;
+    prevLink.textContent = '← Previous';
+    prevLink.className = 'text-blue-500 hover:underline';
+    navButtonsDiv.appendChild(prevLink);
+  } else {
+    // Add an empty span to maintain layout if no prev button
+    navButtonsDiv.appendChild(document.createElement('span'));
+  }
+
+  if (note.next) {
+    const nextLink = document.createElement('a');
+    nextLink.href = `#${note.next}`;
+    nextLink.textContent = 'Next →';
+    nextLink.className = 'text-blue-500 hover:underline';
+    navButtonsDiv.appendChild(nextLink);
+  } else {
+    // Add an empty span to maintain layout if no next button
+    navButtonsDiv.appendChild(document.createElement('span'));
+  }
 }
 
 // 處理 hash 導航


### PR DESCRIPTION
This commit implements a previous/next post navigation feature to improve the browsing experience between notes.

Changes include:
- Modified `js/main.js` to include `prev` and `next` properties in the `notes` array, defining the sequence of posts.
- Updated the `loadNote` function in `js/main.js` to dynamically generate "Previous" and "Next" buttons based on these properties. The buttons are appended below the note content.
- Added Tailwind CSS classes directly in `js/main.js` for quick styling of the navigation elements.
- Added corresponding CSS rules in `css/style.css` to ensure consistent styling for the navigation buttons, including a top border, flex layout for positioning, and link styling for light and dark modes.